### PR TITLE
Adds virtual destructor to DesktopEnv

### DIFF
--- a/src/desktop/desktop_env.h
+++ b/src/desktop/desktop_env.h
@@ -37,6 +37,8 @@ class DesktopEnv {
   static DesktopEnv* getDesktopEnv();
   static QString getDesktopEnvName();
 
+  virtual ~DesktopEnv() = default;
+
   virtual QString getApplicationMenuIcon() const { return "start-here"; }
 
   // System categories (e.g. Session/Power) on the Application Menu.


### PR DESCRIPTION
This deals with the Clang delete-non-abstract-non-virtual-dtor warning