### PR TITLE
Remove stdc++fs from linker options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,7 +120,7 @@ set(SRCS
     view/wallpaper_settings_dialog.ui)
 add_library(crystal-dock_lib STATIC ${SRCS})
 
-set(LIBS Qt6::DBus Qt6::GuiPrivate Qt6::Widgets Wayland::Client LayerShellQt::Interface stdc++fs)
+set(LIBS Qt6::DBus Qt6::GuiPrivate Qt6::Widgets Wayland::Client LayerShellQt::Interface)
 target_link_libraries(crystal-dock_lib ${LIBS})
 
 add_executable(crystal-dock main.cc)


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/filesystem.html#Notes : 

`stdc++fs` is not required any more when using file system library (std::filesystem)  in GCC 9.1+ and LLVM 9.0+.
This also resolves the issue of building with libc++.