### PR TITLE
Add icon hover glow and press darken effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea/

--- a/src/model/multi_dock_model.cc
+++ b/src/model/multi_dock_model.cc
@@ -57,6 +57,8 @@ constexpr char MultiDockModel::kFirstRunMultiScreen[];
 constexpr char MultiDockModel::kFirstRunWindowCountIndicator[];
 
 constexpr char MultiDockModel::kTooltipFontSize[];
+constexpr char MultiDockModel::kHoverGlow[];
+constexpr char MultiDockModel::kHoverGlowAlpha[];
 constexpr char MultiDockModel::kApplicationMenuCategory[];
 constexpr char MultiDockModel::kLabel[];
 constexpr char MultiDockModel::kFontSize[];

--- a/src/model/multi_dock_model.h
+++ b/src/model/multi_dock_model.h
@@ -70,6 +70,8 @@ constexpr char kDefaultInactiveIndicatorColorMetal2D[] = "cyan";
 constexpr int kDefaultFloatingMargin = 6;
 constexpr bool kDefaultBouncingLauncherIcon = true;
 constexpr int kDefaultZoomingAnimationSpeed = 16;
+constexpr bool kDefaultHoverGlow = true;
+constexpr float kDefaultHoverGlowAlpha = 0.3;
 
 constexpr float kLargeClockFontScaleFactor = 1.0;
 constexpr float kMediumClockFontScaleFactor = 0.8;
@@ -289,6 +291,23 @@ class MultiDockModel : public QObject {
   void setShowTooltip(bool value) {
     setAppearanceProperty(kGeneralCategory, kShowTooltip, value);
   }
+
+  bool hoverGlow() const {
+    return appearanceProperty(kGeneralCategory, kHoverGlow, kDefaultHoverGlow);
+  }
+
+  void setHoverGlow(bool value) {
+    setAppearanceProperty(kGeneralCategory, kHoverGlow, value);
+  }
+
+  float hoverGlowAlpha() const {
+    return appearanceProperty(kGeneralCategory, kHoverGlowAlpha, kDefaultHoverGlowAlpha);
+  }
+
+  void setHoverGlowAlpha(float value) {
+    setAppearanceProperty(kGeneralCategory, kHoverGlowAlpha, value);
+  }
+
 
   int tooltipFontSize() const {
     return appearanceProperty(kGeneralCategory, kTooltipFontSize,
@@ -739,6 +758,8 @@ class MultiDockModel : public QObject {
   static constexpr char kMinimumIconSize[] = "minimumIconSize";
   static constexpr char kSpacingFactor[] = "spacingFactor";
   static constexpr char kShowTooltip[] = "showTooltip";
+  static constexpr char kHoverGlow[] = "hoverGlow";
+  static constexpr char kHoverGlowAlpha[] = "hoverGlowAlpha";
   static constexpr char kTooltipFontSize[] = "tooltipFontSize";
   static constexpr char kPanelStyle[] = "panelStyle";
   static constexpr char kFloatingMargin[] = "floatingMargin";

--- a/src/view/appearance_settings_dialog.cc
+++ b/src/view/appearance_settings_dialog.cc
@@ -112,6 +112,8 @@ void AppearanceSettingsDialog::loadData() {
   ui->floatingMargin->setValue(model_->floatingMargin());
   ui->floatingMargin->setEnabled(model_->isFloating());
   ui->bouncingLauncherIcon->setChecked(model_->bouncingLauncherIcon());
+  ui->hoverGlow->setChecked(model_->hoverGlow());
+  ui->hoverGlowAlpha->setValue(model_->hoverGlowAlpha());
 }
 
 void AppearanceSettingsDialog::resetData() {
@@ -143,6 +145,8 @@ void AppearanceSettingsDialog::resetData() {
   ui->tooltipFontSize->setValue(kDefaultTooltipFontSize);
   ui->floatingMargin->setValue(kDefaultFloatingMargin);
   ui->bouncingLauncherIcon->setChecked(kDefaultBouncingLauncherIcon);
+  ui->hoverGlow->setChecked(kDefaultHoverGlow);
+  ui->hoverGlowAlpha->setValue(kDefaultHoverGlowAlpha);
 }
 
 void AppearanceSettingsDialog::saveData() {
@@ -179,6 +183,8 @@ void AppearanceSettingsDialog::saveData() {
   model_->setTooltipFontSize(ui->tooltipFontSize->value());
   model_->setFloatingMargin(ui->floatingMargin->value());
   model_->setBouncingLauncherIcon(ui->bouncingLauncherIcon->isChecked());
+  model_->setHoverGlow(ui->hoverGlow->isChecked());
+  model_->setHoverGlowAlpha(ui->hoverGlowAlpha->value());
   model_->saveAppearanceConfig();
 }
 

--- a/src/view/appearance_settings_dialog.ui
+++ b/src/view/appearance_settings_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>540</height>
+    <height>620</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>34</x>
-     <y>470</y>
+     <y>570</y>
      <width>730</width>
      <height>36</height>
     </rect>
@@ -367,6 +367,73 @@
    <property name="checked">
     <bool>false</bool>
    </property>
+  </widget>
+  <widget class="QGroupBox" name="hoverGlowGroup">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>450</y>
+     <width>760</width>
+     <height>110</height>
+    </rect>
+   </property>
+    <property name="title">
+     <string>Hover Icon Glow</string>
+    </property>
+   <widget class="QCheckBox" name="hoverGlow">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>150</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Enable</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="hoverGlowAlphaLabel">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>70</y>
+      <width>150</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Alpha</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="hoverGlowAlpha">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>70</y>
+      <width>100</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.100000000000000</double>
+    </property>
+    <property name="maximum">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="singleStep">
+     <double>0.050000000000000</double>
+    </property>
+    <property name="value">
+     <double>0.300000000000000</double>
+    </property>
+   </widget>
   </widget>
  </widget>
  <resources/>

--- a/src/view/desktop_selector.cc
+++ b/src/view/desktop_selector.cc
@@ -85,16 +85,21 @@ void DesktopSelector::draw(QPainter* painter) const {
 }
 
 void DesktopSelector::mousePressEvent(QMouseEvent* e) {
+  if (e->button() == Qt::RightButton) {
+    // In case other DesktopSelectors have changed the config.
+    showDesktopNumberAction_->setChecked(model_->showDesktopNumber());
+    showPopupMenu(&menu_);
+  }
+  // Left button press is now handled in mouseReleaseEvent for better UX
+}
+
+void DesktopSelector::mouseReleaseEvent(QMouseEvent* e) {
   if (e->button() == Qt::LeftButton) {
     if (isCurrentDesktop()) {
       WindowSystem::setShowingDesktop(!WindowSystem::showingDesktop());
     } else {
       WindowSystem::setCurrentDesktop(desktop_.id);
     }
-  } else if (e->button() == Qt::RightButton) {
-    // In case other DesktopSelectors have changed the config.
-    showDesktopNumberAction_->setChecked(model_->showDesktopNumber());
-    showPopupMenu(&menu_);
   }
 }
 

--- a/src/view/desktop_selector.h
+++ b/src/view/desktop_selector.h
@@ -55,6 +55,7 @@ class DesktopSelector : public QObject, public IconBasedDockItem {
 
   void draw(QPainter* painter) const override;
   void mousePressEvent(QMouseEvent* e) override;
+  void mouseReleaseEvent(QMouseEvent* e) override;
   void loadConfig() override;
 
   // Sets the icon but scales the pixmap to the screen's width/height ratio.

--- a/src/view/dock_item.h
+++ b/src/view/dock_item.h
@@ -56,6 +56,9 @@ class DockItem {
   // Mouse press event handler.
   virtual void mousePressEvent(QMouseEvent* e) = 0;
 
+  // Mouse release event handler.
+  virtual void mouseReleaseEvent(QMouseEvent* e) {}
+
   // We manually reset active window on the dock's mouse event.
   // We don't want to always do this (e.g. handle this in window_system::state_change() handler)
   // because otherwise we wouldn't be able to click on an active window's icon to minimize it
@@ -102,6 +105,12 @@ class DockItem {
 
   // For a Program dock item.
   virtual void setDemandsAttention(bool demandsAttention) {}
+
+  // Visual feedback functionality
+  virtual void setHovered(bool hovered) { isHovered_ = hovered; }
+  virtual bool isHovered() const { return isHovered_; }
+  virtual void setPressed(bool pressed) { isPressed_ = pressed; }
+  virtual bool isPressed() const { return isPressed_; }
 
   bool isHorizontal() const { return orientation_ == Qt::Horizontal; }
 
@@ -189,6 +198,10 @@ class DockItem {
   int endSize_;
   int currentStep_;
   int numSteps_;
+
+  // Visual feedback states
+  bool isHovered_ = false;
+  bool isPressed_ = false;
 
  private:
   friend class DockPanel;

--- a/src/view/dock_panel.h
+++ b/src/view/dock_panel.h
@@ -252,6 +252,7 @@ class DockPanel : public QWidget {
   virtual void paintEvent(QPaintEvent* e) override;
   virtual void mouseMoveEvent(QMouseEvent* e) override;
   virtual void mousePressEvent(QMouseEvent* e) override;
+  virtual void mouseReleaseEvent(QMouseEvent* e) override;
   virtual void wheelEvent(QWheelEvent* e) override;
   virtual void enterEvent(QEnterEvent* e) override;
   virtual void leaveEvent(QEvent* e) override;
@@ -421,6 +422,7 @@ class DockPanel : public QWidget {
   // The list of all dock items.
   std::vector<std::unique_ptr<DockItem>> items_;
   int activeItem_ = -1;
+  int pressedItem_ = -1;  // Track which item was pressed to ensure press/release match
 
   // Context (right-click) menu.
   QMenu menu_;

--- a/src/view/icon_based_dock_item.cc
+++ b/src/view/icon_based_dock_item.cc
@@ -46,8 +46,20 @@ IconBasedDockItem::IconBasedDockItem(DockPanel* parent, MultiDockModel* model, c
 
 void IconBasedDockItem::draw(QPainter* painter) const {
   const auto& icon = icons_[size_ - minSize_];
+  
   if (!icon.isNull()) {
-    painter->drawPixmap(left_, top_, icon);
+    // Step 1: Draw the icon itself (normal or darkened)
+    if (isPressed_) {
+      drawDarkenedIcon(icon, left_, top_, painter);
+    } else {
+      painter->drawPixmap(left_, top_, icon);
+    }
+    
+    // Step 2: Add brightness overlay if hovered (makes icon itself glow)
+    if (isHovered_ && model_->hoverGlow() && !isPressed_) {
+      QColor glowColor = model_->backgroundColor().lighter(200);
+      drawGlowingIcon(icon, left_, top_, painter, glowColor, model_->hoverGlowAlpha());
+    }
   } else {  // Fall-back "icon".
     QColor fillColor = model_->backgroundColor();
     fillColor.setAlphaF(kDefaultBackgroundAlpha);

--- a/src/view/program.cc
+++ b/src/view/program.cc
@@ -165,6 +165,13 @@ void Program::draw(QPainter *painter) const {
 }
 
 void Program::mousePressEvent(QMouseEvent* e) {
+  if (e->button() == Qt::RightButton) {
+    showPopupMenu(&menu_);
+  }
+  // Left button press is now handled in mouseReleaseEvent for better UX
+}
+
+void Program::mouseReleaseEvent(QMouseEvent* e) {
   if (e->button() == Qt::LeftButton) { // Run the application.
     if (appId_ == kLockScreenId) {
       parent_->leaveEvent(nullptr);
@@ -209,8 +216,6 @@ void Program::mousePressEvent(QMouseEvent* e) {
         }
       }
     }
-  } else if (e->button() == Qt::RightButton) {
-    showPopupMenu(&menu_);
   }
 }
 

--- a/src/view/program.h
+++ b/src/view/program.h
@@ -60,6 +60,7 @@ class Program : public QObject, public IconBasedDockItem {
   void draw(QPainter* painter) const override;
 
   void mousePressEvent(QMouseEvent* e) override;
+  void mouseReleaseEvent(QMouseEvent* e) override;
 
   QString getLabel() const override;
 

--- a/src/view/trash.cc
+++ b/src/view/trash.cc
@@ -72,10 +72,15 @@ void Trash::draw(QPainter* painter) const {
 }
 
 void Trash::mousePressEvent(QMouseEvent* e) {
+  if (e->button() == Qt::RightButton) {
+    showPopupMenu(&menu_);
+  }
+  // Left button press is now handled in mouseReleaseEvent for better UX
+}
+
+void Trash::mouseReleaseEvent(QMouseEvent* e) {
   if (e->button() == Qt::LeftButton) {
     openTrash();
-  } else if (e->button() == Qt::RightButton) {
-    showPopupMenu(&menu_);
   }
 }
 

--- a/src/view/trash.h
+++ b/src/view/trash.h
@@ -44,6 +44,7 @@ class Trash : public QObject, public IconBasedDockItem {
 
   void draw(QPainter* painter) const override;
   void mousePressEvent(QMouseEvent* e) override;
+  void mouseReleaseEvent(QMouseEvent* e) override;
   QString getLabel() const override;
   bool beforeTask(const QString& program) override { return false; }
 

--- a/src/view/version_checker.cc
+++ b/src/view/version_checker.cc
@@ -60,13 +60,18 @@ VersionChecker::VersionChecker(DockPanel* parent, MultiDockModel* model,
 }
 
 void VersionChecker::mousePressEvent(QMouseEvent* e) {
+  if (e->button() == Qt::RightButton) {
+    showPopupMenu(&menu_);
+  }
+  // Left button press is now handled in mouseReleaseEvent for better UX
+}
+
+void VersionChecker::mouseReleaseEvent(QMouseEvent* e) {
   if (e->button() == Qt::LeftButton) {
     parent_->minimize();
     QTimer::singleShot(DockPanel::kExecutionDelayMs, [this]{
       showVersionInfo();
     });
-  } else if (e->button() == Qt::RightButton) {
-    showPopupMenu(&menu_);
   }
 }
 

--- a/src/view/version_checker.h
+++ b/src/view/version_checker.h
@@ -36,6 +36,7 @@ class VersionChecker : public QObject, public IconBasedDockItem {
 
   bool beforeTask(const QString& program) override { return false; }
   void mousePressEvent(QMouseEvent* e) override;
+  void mouseReleaseEvent(QMouseEvent* e) override;
 
  private:
   void checkVersion();


### PR DESCRIPTION
Implements configurable hover glow and press darken effects for dock icons to provide better visual feedback. 
Also add a mouseReleaseEvent to better handle mouse press down logic.