### PR TITLE
Added glow/darken effect when the cursor hover/press icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea/

--- a/src/model/multi_dock_model.cc
+++ b/src/model/multi_dock_model.cc
@@ -57,6 +57,8 @@ constexpr char MultiDockModel::kFirstRunMultiScreen[];
 constexpr char MultiDockModel::kFirstRunWindowCountIndicator[];
 
 constexpr char MultiDockModel::kTooltipFontSize[];
+constexpr char MultiDockModel::kHoverGlow[];
+constexpr char MultiDockModel::kHoverGlowAlpha[];
 constexpr char MultiDockModel::kApplicationMenuCategory[];
 constexpr char MultiDockModel::kLabel[];
 constexpr char MultiDockModel::kFontSize[];

--- a/src/model/multi_dock_model.h
+++ b/src/model/multi_dock_model.h
@@ -70,6 +70,8 @@ constexpr char kDefaultInactiveIndicatorColorMetal2D[] = "cyan";
 constexpr int kDefaultFloatingMargin = 6;
 constexpr bool kDefaultBouncingLauncherIcon = true;
 constexpr int kDefaultZoomingAnimationSpeed = 16;
+constexpr bool kDefaultHoverGlow = true;
+constexpr float kDefaultHoverGlowAlpha = 0.3;
 
 constexpr float kLargeClockFontScaleFactor = 1.0;
 constexpr float kMediumClockFontScaleFactor = 0.8;
@@ -289,6 +291,23 @@ class MultiDockModel : public QObject {
   void setShowTooltip(bool value) {
     setAppearanceProperty(kGeneralCategory, kShowTooltip, value);
   }
+
+  bool hoverGlow() const {
+    return appearanceProperty(kGeneralCategory, kHoverGlow, kDefaultHoverGlow);
+  }
+
+  void setHoverGlow(bool value) {
+    setAppearanceProperty(kGeneralCategory, kHoverGlow, value);
+  }
+
+  float hoverGlowAlpha() const {
+    return appearanceProperty(kGeneralCategory, kHoverGlowAlpha, kDefaultHoverGlowAlpha);
+  }
+
+  void setHoverGlowAlpha(float value) {
+    setAppearanceProperty(kGeneralCategory, kHoverGlowAlpha, value);
+  }
+
 
   int tooltipFontSize() const {
     return appearanceProperty(kGeneralCategory, kTooltipFontSize,
@@ -739,6 +758,8 @@ class MultiDockModel : public QObject {
   static constexpr char kMinimumIconSize[] = "minimumIconSize";
   static constexpr char kSpacingFactor[] = "spacingFactor";
   static constexpr char kShowTooltip[] = "showTooltip";
+  static constexpr char kHoverGlow[] = "hoverGlow";
+  static constexpr char kHoverGlowAlpha[] = "hoverGlowAlpha";
   static constexpr char kTooltipFontSize[] = "tooltipFontSize";
   static constexpr char kPanelStyle[] = "panelStyle";
   static constexpr char kFloatingMargin[] = "floatingMargin";

--- a/src/utils/draw_utils.h
+++ b/src/utils/draw_utils.h
@@ -77,6 +77,52 @@ inline void drawHighlightedIcon(QColor bgColor, int left, int top, int width, in
   painter->setRenderHint(QPainter::Antialiasing, false);
 }
 
+inline void drawDarkenedIcon(const QPixmap& icon, int left, int top, QPainter* painter,
+                             float darkenFactor = 0.6) {
+  QImage iconImage = icon.toImage().convertToFormat(QImage::Format_ARGB32);
+
+  for (int y = 0; y < iconImage.height(); ++y) {
+    QRgb* line = reinterpret_cast<QRgb*>(iconImage.scanLine(y));
+    for (int x = 0; x < iconImage.width(); ++x) {
+      QRgb pixel = line[x];
+      int alpha = qAlpha(pixel);
+      if (alpha > 0) {
+        int r = qRed(pixel) * darkenFactor;
+        int g = qGreen(pixel) * darkenFactor;
+        int b = qBlue(pixel) * darkenFactor;
+        line[x] = qRgba(r, g, b, alpha);
+      }
+    }
+  }
+  
+  painter->drawImage(left, top, iconImage);
+}
+
+inline void drawGlowingIcon(const QPixmap& icon, int left, int top, QPainter* painter,
+                            QColor glowColor, float glowAlpha) {
+  QImage iconImage = icon.toImage().convertToFormat(QImage::Format_ARGB32);
+  
+  painter->save();
+  painter->setCompositionMode(QPainter::CompositionMode_SourceAtop);
+  
+  QImage brightOverlay = iconImage.copy();
+
+  for (int y = 0; y < brightOverlay.height(); ++y) {
+    QRgb* line = reinterpret_cast<QRgb*>(brightOverlay.scanLine(y));
+    for (int x = 0; x < brightOverlay.width(); ++x) {
+      QRgb pixel = line[x];
+      int pixelAlpha = qAlpha(pixel);
+      if (pixelAlpha > 0) {
+        int finalAlpha = pixelAlpha * glowAlpha;
+        line[x] = qRgba(glowColor.red(), glowColor.green(), glowColor.blue(), finalAlpha);
+      }
+    }
+  }
+  
+  painter->drawImage(left, top, brightOverlay);
+  painter->restore();
+}
+
 inline void fillRoundedRect(int x, int y, int width, int height, int radius, bool showBorder,
                             QColor borderColor, QColor fillColor, QPainter* painter) {
   painter->setRenderHint(QPainter::Antialiasing);

--- a/src/view/appearance_settings_dialog.cc
+++ b/src/view/appearance_settings_dialog.cc
@@ -112,6 +112,8 @@ void AppearanceSettingsDialog::loadData() {
   ui->floatingMargin->setValue(model_->floatingMargin());
   ui->floatingMargin->setEnabled(model_->isFloating());
   ui->bouncingLauncherIcon->setChecked(model_->bouncingLauncherIcon());
+  ui->hoverGlow->setChecked(model_->hoverGlow());
+  ui->hoverGlowAlpha->setValue(model_->hoverGlowAlpha());
 }
 
 void AppearanceSettingsDialog::resetData() {
@@ -143,6 +145,8 @@ void AppearanceSettingsDialog::resetData() {
   ui->tooltipFontSize->setValue(kDefaultTooltipFontSize);
   ui->floatingMargin->setValue(kDefaultFloatingMargin);
   ui->bouncingLauncherIcon->setChecked(kDefaultBouncingLauncherIcon);
+  ui->hoverGlow->setChecked(kDefaultHoverGlow);
+  ui->hoverGlowAlpha->setValue(kDefaultHoverGlowAlpha);
 }
 
 void AppearanceSettingsDialog::saveData() {
@@ -179,6 +183,8 @@ void AppearanceSettingsDialog::saveData() {
   model_->setTooltipFontSize(ui->tooltipFontSize->value());
   model_->setFloatingMargin(ui->floatingMargin->value());
   model_->setBouncingLauncherIcon(ui->bouncingLauncherIcon->isChecked());
+  model_->setHoverGlow(ui->hoverGlow->isChecked());
+  model_->setHoverGlowAlpha(ui->hoverGlowAlpha->value());
   model_->saveAppearanceConfig();
 }
 

--- a/src/view/appearance_settings_dialog.ui
+++ b/src/view/appearance_settings_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>540</height>
+    <height>620</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>34</x>
-     <y>470</y>
+     <y>570</y>
      <width>730</width>
      <height>36</height>
     </rect>
@@ -367,6 +367,73 @@
    <property name="checked">
     <bool>false</bool>
    </property>
+  </widget>
+  <widget class="QGroupBox" name="hoverGlowGroup">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>450</y>
+     <width>760</width>
+     <height>110</height>
+    </rect>
+   </property>
+    <property name="title">
+     <string>Hover Icon Glow</string>
+    </property>
+   <widget class="QCheckBox" name="hoverGlow">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>150</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Enable</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="hoverGlowAlphaLabel">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>70</y>
+      <width>150</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Alpha</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="hoverGlowAlpha">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>70</y>
+      <width>100</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>2</number>
+    </property>
+    <property name="minimum">
+     <double>0.100000000000000</double>
+    </property>
+    <property name="maximum">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="singleStep">
+     <double>0.050000000000000</double>
+    </property>
+    <property name="value">
+     <double>0.300000000000000</double>
+    </property>
+   </widget>
   </widget>
  </widget>
  <resources/>

--- a/src/view/dock_item.h
+++ b/src/view/dock_item.h
@@ -103,6 +103,12 @@ class DockItem {
   // For a Program dock item.
   virtual void setDemandsAttention(bool demandsAttention) {}
 
+  // Visual feedback functionality
+  virtual void setHovered(bool hovered) { isHovered_ = hovered; }
+  virtual bool isHovered() const { return isHovered_; }
+  virtual void setPressed(bool pressed) { isPressed_ = pressed; }
+  virtual bool isPressed() const { return isPressed_; }
+
   bool isHorizontal() const { return orientation_ == Qt::Horizontal; }
 
   void setAnimationStartAsCurrent() {
@@ -189,6 +195,10 @@ class DockItem {
   int endSize_;
   int currentStep_;
   int numSteps_;
+
+  // Visual feedback states
+  bool isHovered_ = false;
+  bool isPressed_ = false;
 
  private:
   friend class DockPanel;

--- a/src/view/dock_panel.h
+++ b/src/view/dock_panel.h
@@ -220,6 +220,9 @@ class DockPanel : public QWidget {
   // Slot to update zoom animation.
   void updateAnimation();
 
+  // Slot to reset pressed state after a short delay.
+  void resetPressedState();
+
   void showOnlineDocumentation();
 
   void about();
@@ -421,6 +424,7 @@ class DockPanel : public QWidget {
   // The list of all dock items.
   std::vector<std::unique_ptr<DockItem>> items_;
   int activeItem_ = -1;
+  int pressedItem_ = -1;
 
   // Context (right-click) menu.
   QMenu menu_;
@@ -465,6 +469,7 @@ class DockPanel : public QWidget {
   bool isAnimationActive_;
   bool isShowingPopup_;
   std::unique_ptr<QTimer> animationTimer_;
+  std::unique_ptr<QTimer> pressedResetTimer_;
   int currentAnimationStep_;
   int backgroundWidth_;
   int startBackgroundWidth_;

--- a/src/view/icon_based_dock_item.cc
+++ b/src/view/icon_based_dock_item.cc
@@ -47,7 +47,18 @@ IconBasedDockItem::IconBasedDockItem(DockPanel* parent, MultiDockModel* model, c
 void IconBasedDockItem::draw(QPainter* painter) const {
   const auto& icon = icons_[size_ - minSize_];
   if (!icon.isNull()) {
-    painter->drawPixmap(left_, top_, icon);
+    // Step 1: Draw the icon itself (normal or darkened)
+    if (isPressed_) {
+      drawDarkenedIcon(icon, left_, top_, painter);
+    } else {
+      painter->drawPixmap(left_, top_, icon);
+    }
+
+    // Step 2: Add brightness overlay if hovered (makes icon itself glow)
+    if (isHovered_ && model_->hoverGlow() && !isPressed_) {
+      QColor glowColor = model_->backgroundColor().lighter(200);
+      drawGlowingIcon(icon, left_, top_, painter, glowColor, model_->hoverGlowAlpha());
+    }
   } else {  // Fall-back "icon".
     QColor fillColor = model_->backgroundColor();
     fillColor.setAlphaF(kDefaultBackgroundAlpha);


### PR DESCRIPTION
Without the mouse release event, the darken effect(pressed state) could be simply reset by a single shot timer.